### PR TITLE
add path to files from Gentoo app-i18n/unicode-data package

### DIFF
--- a/unicode
+++ b/unicode
@@ -588,6 +588,7 @@ def print_characters(clist, maxcount, format_string, query_wikipedia=0, query_wi
         utf8 = ' '.join([("%02x" % ord23(x)) for x in c.encode('utf-8')])
         utf16be = ''.join([("%02x" % ord23(x)) for x in c.encode('utf-16be')])
         decimal = "&#%s;" % ordc
+        octal = "\\%o" % ordc
 
         addcharset = options.addcharset
         if addcharset:
@@ -726,7 +727,7 @@ def unescape(s):
     return s.replace(r'\n', '\n')
 
 format_string_default = '''{yellow}{bold}U+{ordc:04X} {name}{default}
-{green}UTF-8:{default} {utf8} {green}UTF-16BE:{default} {utf16be} {green}Decimal:{default} {decimal}{opt_additional}
+{green}UTF-8:{default} {utf8} {green}UTF-16BE:{default} {utf16be} {green}Decimal:{default} {decimal} {green}Octal:{default} {octal}{opt_additional}
 {pchar}{opt_flipcase}{opt_uppercase}{opt_lowercase}
 {green}Category:{default} {category} ({category_desc})
 {green}{opt_numeric}{default}{numeric_desc}{green}{opt_digit}{default}{digit_desc}{green}{opt_bidi}{default}{bidi}{bidi_desc}

--- a/unicode
+++ b/unicode
@@ -250,14 +250,14 @@ def do_init():
     HomeDir = os.path.expanduser('~/.unicode')
     HomeUnicodeData = os.path.join(HomeDir, "UnicodeData.txt")
     global UnicodeDataFileNames
-    UnicodeDataFileNames = [HomeUnicodeData, '/usr/share/unicode/UnicodeData.txt', '/usr/share/unidata/UnicodeData.txt', './UnicodeData.txt'] + \
+    UnicodeDataFileNames = [HomeUnicodeData, '/usr/share/unicode/UnicodeData.txt', '/usr/share/unicode-data/UnicodeData.txt', '/usr/share/unidata/UnicodeData.txt', './UnicodeData.txt'] + \
         glob.glob('/usr/share/unidata/UnicodeData*.txt') + \
         glob.glob('/usr/share/perl/*/unicore/UnicodeData.txt') + \
         glob.glob('/System/Library/Perl/*/unicore/UnicodeData.txt') # for MacOSX
 
     HomeUnihanData = os.path.join(HomeDir, "Unihan*")
     global UnihanDataGlobs
-    UnihanDataGlobs = [HomeUnihanData, '/usr/share/unidata/Unihan*', '/usr/share/unicode/Unihan*', './Unihan*']
+    UnihanDataGlobs = [HomeUnihanData, '/usr/share/unidata/Unihan*', '/usr/share/unicode-data/Unihan*', '/usr/share/unicode/Unihan*', './Unihan*']
 
 
 def get_unihan_files():


### PR DESCRIPTION
This patch adds path to unicode data files provided by Gentoo package app-i18n/unicode-data. 
This package has newer data than those provided by python.
