### PR TITLE
Also look for /usr/share/unicode/ucd/UnicodeData.txt

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,8 @@ To use unicode utility, you need:
  - UnicodeData.txt file (http://www.unicode.org/Public) which
    you should put into /usr/share/unicode/, ~/.unicode/ or current
    working directory.
+    - apt-get install unicode-data  # Debian
+    - dnf install unicode-ucd       # Fedora
  - if you want to see UniHan properties, you need also Unihan.txt file
    which should be put into /usr/share/unicode/, ~./unicode/ or
    current working directory.

--- a/unicode
+++ b/unicode
@@ -281,7 +281,7 @@ def do_init():
     HomeDir = os.path.expanduser('~/.unicode')
     HomeUnicodeData = os.path.join(HomeDir, "UnicodeData.txt")
     global UnicodeDataFileNames
-    UnicodeDataFileNames = [HomeUnicodeData, '/usr/share/unicode/UnicodeData.txt', '/usr/share/unicode-data/UnicodeData.txt', '/usr/share/unidata/UnicodeData.txt', './UnicodeData.txt'] + \
+    UnicodeDataFileNames = [HomeUnicodeData, '/usr/share/unicode/UnicodeData.txt', '/usr/share/unicode-data/UnicodeData.txt', '/usr/share/unidata/UnicodeData.txt', '/usr/share/unicode/ucd/UnicodeData.txt', './UnicodeData.txt'] + \
         glob.glob('/usr/share/unidata/UnicodeData*.txt') + \
         glob.glob('/usr/share/perl/*/unicore/UnicodeData.txt') + \
         glob.glob('/System/Library/Perl/*/unicore/UnicodeData.txt') # for MacOSX


### PR DESCRIPTION
unicode-ucd package on Fedora and CentOS/RHEL installs it there.
http://rpms.famillecollet.com/rpmphp/zoom.php?rpm=unicode-ucd
https://admin.fedoraproject.org/pkgdb/package/rpms/unicode-ucd/

Mentioned the fedora and debian packages in README.
(They don't install Unihan.txt though.
 Debian's has several Unihan_*.txt.bz2 files:
 https://packages.debian.org/sid/all/unicode-data/filelist)
