### PR TITLE
Add "identifier" format string (U+xxxx)

### DIFF
--- a/README
+++ b/README
@@ -99,6 +99,7 @@ recognized:
 {concealed}                      -- self-explaining ANSI escape codes
 
 {ordc} -- unicode codepoint of the character (integer)
+{identifier} -- unicode identifier of the character (U+xxxx)
 {name} -- unicode name of the character
 {utf8} -- utf8 representation of the character (hexadecimal)
 {utf16be} -- utf16 representation of the character (hexadecimal)

--- a/unicode
+++ b/unicode
@@ -617,6 +617,7 @@ def print_characters(clist, maxcount, format_string, query_wikipedia=0, query_wi
             locals()[colour_key] = maybe_colours(colour_key)
         properties = get_unicode_properties(c)
         ordc = ord(c)
+        identifier = "U+%04X" % ordc
         if properties['name']:
             name = properties['name']
         else:
@@ -777,7 +778,7 @@ def is_range(s, typ):
 def unescape(s):
     return s.replace(r'\n', '\n')
 
-format_string_default = '''{yellow}{bold}U+{ordc:04X} {name}{default}
+format_string_default = '''{yellow}{bold}{identifier} {name}{default}
 {green}UTF-8:{default} {utf8} {green}UTF-16BE:{default} {utf16be} {green}Decimal:{default} {decimal} {green}Octal:{default} {octal}{opt_additional}
 {pchar}{opt_flipcase}{opt_uppercase}{opt_lowercase}
 {green}Category:{default} {category} ({category_desc})
@@ -850,7 +851,7 @@ def main():
           help="formatting string")
     parser.add_option("--brief", "--terse",
           action="store_const", dest="format_string",
-          const='{pchar} U+{ordc:04X} {name}\n',
+          const='{pchar} {identifier} {name}\n',
           help="Brief format")
 
     global options


### PR DESCRIPTION
Feel free to ignore as this is not a very substantial change.

Initially because I wanted to do --format "{identifier} {name}\n" before I realized using --format "U+{ordc:04X}..." was an option.