### PR TITLE
Performance enhancement: Set color variables outside of the loop

### DIFF
--- a/unicode
+++ b/unicode
@@ -597,6 +597,10 @@ def print_characters(clist, maxcount, format_string, query_wikipedia=0, query_wi
             1 - spawn browser
     """
     counter = 0
+
+    for colour_key in colours.keys():
+        locals()[colour_key] = maybe_colours(colour_key)
+
     for c in clist:
 
         if query_wikipedia or query_wiktionary:
@@ -613,8 +617,6 @@ def print_characters(clist, maxcount, format_string, query_wikipedia=0, query_wi
         if counter > options.maxcount:
             out("\nToo many characters to display, more than %s, use --max option to change it\n" % options.maxcount)
             return
-        for colour_key in colours.keys():
-            locals()[colour_key] = maybe_colours(colour_key)
         properties = get_unicode_properties(c)
         ordc = ord(c)
         if properties['name']:


### PR DESCRIPTION
Dear maintainer, 

While listing all characters in database I noticed a trivial improvement that should  speed up listing without changing the output. I hope I'm not missing something obvious.

Rest is copied from commit message:

Color settings don't change between iterations thus there is no need to
set it in every iteration.

locals() call takes a relatively long time and this makes script finish
slower in case a lot of characters are printed.

Here is a benchmark result before and after this change:

```
$ time ./unicode.orig --max=0 --regexp . >/dev/null

real	0m5.290s
user	0m5.232s
sys	0m0.048s
$ time ./unicode --max=0 --regexp . >/dev/null

real	0m2.976s
user	0m2.936s
sys	0m0.036s
```