### PR TITLE
Change maxcount message to be printed to stderr for better piping support

### DIFF
--- a/unicode
+++ b/unicode
@@ -635,7 +635,7 @@ def print_characters(clist, maxcount, format_string, query_wikipedia=0, query_wi
         if maxcount:
             counter += 1
         if counter > options.maxcount:
-            out("\nToo many characters to display, more than %s, use --max 0 (or other value) option to change it\n" % options.maxcount)
+            sys.stderr.write("\nToo many characters to display, more than %s, use --max 0 (or other value) option to change it\n" % options.maxcount)
             return
         properties = get_unicode_properties(c)
         ordc = ord(c)


### PR DESCRIPTION
First of all thanks for the unicode tool!

Before this commit one had the problem that when you want to pipe unicode output
e.g. to the clipboard like so `unicode --format="{pchar}" -m1 gear 2> /dev/null | xclip`
the error message was printed to stdout instead of the stderr which made it impossible
to ignore the error and made the error message be part of the clipboard.

With this commit above command would only include the character.

Please note that I didn't test this and just used the GitHub editor.