### PR TITLE
Ensure close is called on opened files.

### DIFF
--- a/unicode
+++ b/unicode
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals, print_function
 
-import os, glob, sys, unicodedata, locale, gzip, re, traceback, encodings, io, codecs, shutil
+import os, glob, sys, unicodedata, locale, gzip, re, traceback, encodings, io, shutil
 import webbrowser, textwrap, struct
 
 #from pprint import pprint
@@ -240,6 +240,7 @@ def get_unicode_blocks_descriptions():
         low = int(low, 16)
         high = int(high, 16)
         unicodeblocks[ (low,high) ] = desc
+    f.close()
     return unicodeblocks
 
 unicodeblocks = None
@@ -343,6 +344,7 @@ def get_unihan_properties_internal(ch):
                 properties[key] = value
             elif int(char[2:], 16)>ch:
                 break
+        fo.close()
     return properties
 
 def get_unihan_properties_zgrep(ch):
@@ -403,22 +405,16 @@ def get_gzip_filename(fname):
 def OpenGzip(fname):
     "open fname, try fname.gz or fname.bz2 or fname.xz if fname does not exist, return file object or GzipFile or BZ2File object"
     fname = get_gzip_filename(fname)
-    fo = None
     if not fname:
         return None
     if fname.endswith('.gz'):
-        fo = gzip.GzipFile(fname)
+        return gzip.open(fname, mode='r', encoding='UTF-8')
     elif fname.endswith('.bz2'):
-        fo = bz2.BZ2File(fname)
+        return bz2.BZ2File(fname, mode='r', encoding='UTF-8')
     elif fname.endswith('.xz'):
-        fo = lzma.open(fname)
+        return lzma.open(fname, mode='r', encoding='UTF-8')
     else:
-        fo = io.open(fname, encoding='utf-8')
-        return fo
-    if fo:
-        # we cannot use TextIOWrapper, since it needs read1 method not implemented by gzip|bz2
-        fo = codecs.getreader('utf-8')(fo)
-        return fo
+        return io.open(fname, encoding='utf-8')
 
 def get_unicode_cur_version():
     # return current version of the Unicode standard, hardwired for now


### PR DESCRIPTION
I'm trying to avoid this warning:
```
/home/mdk/clones/unicode/.venv/bin/unicode:250: ResourceWarning: unclosed file <_io.TextIOWrapper name='/usr/share/unicode/Blocks.txt' mode='r' encoding='utf-8'>
  unicodeblocks = get_unicode_blocks_descriptions()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

Idea was to ensure OpenGzip returns something that has a `close` method, and consistently call the close method.

Sadly I don't have Pythons < 3.7 installed on my machine, I only tried with 3.7 3.8 3.9 3.10 3.11, but I checked the documentations of function I used and it looks like they all always accepted the encoding argument.

I also probably not tried with many variations on gzip/lz/bz2 as I only tested on my Debian.

